### PR TITLE
Added snapcraft configuration instructions for snap package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,10 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Snapcraft build directories and files
+*.snap
+parts
+stage
+prime
+snap/.snapcraft/state

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: pown-proxy
+version: '0.0.1'
+summary: pown-proxy, a Javascript intercepting proxy
+description: |
+  pown-proxy is a Javascript intercepting proxy which can be used as standalone
+  or as part of the pownjs distribution.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+apps:
+  pown-proxy:
+    command: pown-proxy
+    plugs: 
+      - network
+
+parts:
+  pown-proxy:
+    source: https://github.com/pownjs/pown-proxy.git
+    source-tag: v0.0.1
+    plugin: nodejs
+    node-engine: 9.4.0
+
+    node-packages: 
+      - pown-cli


### PR DESCRIPTION
Snaps (https://www.ubuntu.com/desktop/snappy) are installation packages for software and can be installed in most Linux distributions (https://docs.snapcraft.io/core/install).

In this pull request I add support for the generation of a snap package for pown-proxy.

## How to create a snap package for pown-proxy

1. Install _snap_ support for your Linux distribution according to https://docs.snapcraft.io/core/install
2. Install the **snapcraft** utility that can be used to create snap packages of software with `snap install --classic snapcraft`
3. Run **snapcraft** in the source directory of pown-proxy. It will follow the instructions in snap/snapcraft.yaml and generate the package named pown-proxy_0.0.1_amd64.snap.

## How to install the snap (for testing)

Run the following command

`snap install --devmode pown-proxy_0.0.1_amd64.snap`

You can then run `pown-proxy` and use as normal.

## How to publish the snap

See the instructions at https://docs.snapcraft.io/build-snaps/publish
The publishing is instantaneous. Then, users would just need to run `snap install pown-proxy` in order to install the app.
